### PR TITLE
fix: locale switch, convert code to iso

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -31,7 +31,7 @@
               </div>
             </template>
             <div class="py-4 text-center">
-              <a href="/" class="btn btn-primary btn-outline btn-wide">
+              <a href="/" class="btn btn-outline btn-primary btn-wide">
                 {{ $t('btn.back') }}
               </a>
             </div>
@@ -51,11 +51,16 @@
 
 <script setup>
 const localePath = useLocalePath()
-defineProps({
+const props = defineProps({
   error: {
     type: Object,
     required: false,
     default: null
+  }
+})
+watchEffect(() => {
+  if (props.error) {
+    console.error(props.error)
   }
 })
 </script>

--- a/modules/shopinvader/index.ts
+++ b/modules/shopinvader/index.ts
@@ -89,7 +89,7 @@ export default defineNuxtModule<ShopinvaderConfig>({
       handler: resolve('./runtime/server/erpProxy.ts')
     })
 
-    /* I18n */
+    /* Manually add the I18n module to prevent config merge problems */
     await addI18n(nuxt)
 
     /** Components */
@@ -118,6 +118,6 @@ export default defineNuxtModule<ShopinvaderConfig>({
         config.elasticsearch.url
       )
     }
-    nuxt.callHook('shopinvader:loaded' as any, nuxt)
+    await nuxt.callHook('shopinvader:loaded' as any, nuxt)
   }
 })

--- a/modules/shopinvader/runtime/plugins/services.ts
+++ b/modules/shopinvader/runtime/plugins/services.ts
@@ -233,16 +233,16 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   // Manage the language switch
   // --------------------------
-  nuxtApp.hook('i18n:localeSwitched', ({ newLocale }) => {
+  nuxtApp.hook('i18n:localeSwitched', async ({ newLocale }) => {
     // Convert the locale to the iso format (while trying to keep TS typing)
-    // We get 'en' in newLocale but Elastic services want 'en_en' or 'en_us' or 'en_fr'...
+    // We get 'en' in newLocale but Elastic services want 'en_en' or 'en_us'...
     const i18n = nuxtApp.$i18n as NuxtI18nOptions
     const locales = i18n.locales as unknown as Ref<LocaleObject[]>
     const locale = locales?.value?.find((l) => l.code === newLocale)
     const newIsoLocale = locale?.language || 'fr_fr'
     if (services) {
       for (const service of Object.values(services)) {
-        service.changeLocale(newIsoLocale)
+        await service.changeLocale(newIsoLocale)
       }
     }
   })

--- a/modules/shopinvader/runtime/plugins/services.ts
+++ b/modules/shopinvader/runtime/plugins/services.ts
@@ -16,6 +16,7 @@ import {
   SaleService,
   SettingService
 } from '#services'
+import type { LocaleObject, NuxtI18nOptions } from '@nuxtjs/i18n'
 import { ofetch } from 'ofetch'
 import type {
   ShopinvaderServiceList as ServiceList,
@@ -232,11 +233,16 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   // Manage the language switch
   // --------------------------
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  nuxtApp.hook('i18n:localeSwitched', ({ oldLocale, newLocale }) => {
+  nuxtApp.hook('i18n:localeSwitched', ({ newLocale }) => {
+    // Convert the locale to the iso format (while trying to keep TS typing)
+    // We get 'en' in newLocale but Elastic services want 'en_en' or 'en_us' or 'en_fr'...
+    const i18n = nuxtApp.$i18n as NuxtI18nOptions
+    const locales = i18n.locales as unknown as Ref<LocaleObject[]>
+    const locale = locales?.value?.find((l) => l.code === newLocale)
+    const newIsoLocale = locale?.language || 'fr_fr'
     if (services) {
       for (const service of Object.values(services)) {
-        service.changeLocale(newLocale)
+        service.changeLocale(newIsoLocale)
       }
     }
   })

--- a/modules/shopinvader/runtime/utils/addI18n.ts
+++ b/modules/shopinvader/runtime/utils/addI18n.ts
@@ -3,7 +3,8 @@ import type { LocaleObject } from '@nuxtjs/i18n'
 import type { Nuxt } from 'nuxt/schema'
 
 /**
- * Add i18n module to the app with top layer locales
+ * Add i18n module to the app with top layer locales.
+ * This is needed else the i18n module will merge all locales from all layers.
  * @param nuxt
  */
 export const addI18n = async (nuxt: Nuxt) => {
@@ -25,8 +26,7 @@ export const addI18n = async (nuxt: Nuxt) => {
     nuxt.options.i18n = {
       ...nuxt.options.i18n,
       locales,
-      defaultLocale: (locales[0] as LocaleObject)?.code,
-      strategy: 'prefix_except_default'
+      defaultLocale: (locales[0] as LocaleObject)?.code
     }
     config = nuxt.options.i18n || {}
   }

--- a/services/AuthService.ts
+++ b/services/AuthService.ts
@@ -55,11 +55,10 @@ export abstract class AuthService extends BaseServiceLocalized {
     this.storage = nuxtStorage?.localStorage
   }
 
-  override init(services: ShopinvaderServiceList): Promise<any> {
-    super.init(services)
+  override async init(services: ShopinvaderServiceList) {
+    await super.init(services)
     this.urlEndpointAuth = this.buildUrlEndpoint(this.baseUrl, this.authEndpoint)
     this.urlEndpointUser = this.buildUrlEndpoint(this.baseUrl, this.userEndpoint)
-    return Promise.resolve()
   }
 
   buildUrlEndpoint(baseUrl: string, entrypoint: string): string {

--- a/services/BaseService.ts
+++ b/services/BaseService.ts
@@ -37,7 +37,7 @@ export class BaseService {
   // Init is called after custom ShopInvader was allowed to replace or
   // add services in the global list of services. Use this method to
   // initialize all stuff you need to use in your service.
-  init(services: ShopinvaderServiceList) {
+  async init(services: ShopinvaderServiceList) {
     this.services = services
   }
 

--- a/services/BaseServiceErp.ts
+++ b/services/BaseServiceErp.ts
@@ -16,8 +16,8 @@ export class BaseServiceErp extends BaseServiceLocalized {
     this.erpBaseUrl = erpBaseUrl
   }
 
-  override init(services: ShopinvaderServiceList): void {
-    super.init(services)
+  override async init(services: ShopinvaderServiceList) {
+    await super.init(services)
     this.urlEndpoint = this.buildUrlEndpoint(this.erpBaseUrl, this.endpoint)
   }
 

--- a/services/BaseServiceLocalized.ts
+++ b/services/BaseServiceLocalized.ts
@@ -8,7 +8,7 @@ export class BaseServiceLocalized extends BaseService {
     this.currentIsoLocale = isoLocale
   }
 
-  changeLocale(isoLocale: string) {
+  async changeLocale(isoLocale: string) {
     this.currentIsoLocale = isoLocale
   }
 }

--- a/services/CartService.ts
+++ b/services/CartService.ts
@@ -1,8 +1,4 @@
-import type {
-  Address,
-  DeliveryPickupPoint,
-  Product
-} from '#models'
+import type { Address, DeliveryPickupPoint, Product } from '#models'
 import {
   CartLine as CartLineModel,
   Cart as CartModel,
@@ -72,8 +68,8 @@ export class CartService extends BaseServiceErp {
     this.transformCart = this.transformCart.bind(this)
   }
 
-  override init(services: ShopinvaderServiceList): void {
-    super.init(services)
+  override async init(services: ShopinvaderServiceList) {
+    await super.init(services)
     if (!import.meta.env.SSR) {
       const erpFetchWrapper = new ErpFetchWrapper(this.ofetch)
       const observer = new CartObserver(this.setCart)

--- a/services/CategoryService.ts
+++ b/services/CategoryService.ts
@@ -5,9 +5,6 @@ import esb, { MultiMatchQuery } from 'elastic-builder'
 export class CategoryService extends BaseServiceElastic {
   navCategories: Category[] | null = null
 
-  override async init(services: ShopinvaderServiceList) {
-    this.services = services
-  }
   async search(body: any): Promise<CategoryResult> {
     const result = await this.elasticSearch(body)
     const hits = result?.hits?.hits?.map((hit: any) => this.jsonToModel(hit._source))

--- a/services/SaleService.ts
+++ b/services/SaleService.ts
@@ -9,8 +9,8 @@ export class SaleService extends BaseServiceErp {
   public urlEndpointInvoice: string = ''
   public productService: ProductService | null = null
 
-  override init(services: ShopinvaderServiceList) {
-    super.init(services)
+  override async init(services: ShopinvaderServiceList) {
+    await super.init(services)
     this.productService = services.products
     this.urlEndpointInvoice = this.buildUrlEndpoint(this.erpBaseUrl, this.endpointInvoice)
   }

--- a/services/SettingService.ts
+++ b/services/SettingService.ts
@@ -13,7 +13,7 @@ export class SettingService extends BaseServiceErp {
   }
 
   override async init(service: ShopinvaderServiceList) {
-    super.init(service)
+    await super.init(service)
     const res = await this.getAll()
     if (res) {
       this.setValues(res)

--- a/services/auth/AuthCredentialService.ts
+++ b/services/auth/AuthCredentialService.ts
@@ -32,8 +32,8 @@ export class AuthCredentialService extends AuthService {
     }
   }
 
-  override init(services: ShopinvaderServiceList): Promise<any> {
-    super.init(services)
+  override async init(services: ShopinvaderServiceList) {
+    await super.init(services)
     if (this.getSession()) {
       this.profile()
     } else {
@@ -46,7 +46,6 @@ export class AuthCredentialService extends AuthService {
         await navigateTo(this.config.loginPage)
       }
     })
-    return Promise.resolve()
   }
 
   getConfig(): any {

--- a/services/auth/AuthOIDCService.ts
+++ b/services/auth/AuthOIDCService.ts
@@ -26,8 +26,8 @@ export class AuthOIDCService extends AuthService {
     this.config = config
   }
 
-  override async init(services: ShopinvaderServiceList): Promise<any> {
-    super.init(services)
+  override async init(services: ShopinvaderServiceList) {
+    await super.init(services)
     if (!import.meta.env.SSR) {
       const { origin } = useRequestURL()
       this.redirectUri = new URL(this.config.redirectUri, origin).href
@@ -66,7 +66,6 @@ export class AuthOIDCService extends AuthService {
         }
       }
     }
-    return Promise.resolve()
   }
 
   getConfig(): any {


### PR DESCRIPTION
When the user change its locale, Elastic services change the name of targeted indexes because these include the locale. But as the received locale is like 'fr' and the indexes uses the iso locale like fr_be, I adapted the code to convert the locale from code to iso.
Also fixed a bug in the shopinvader module: the i18n strategy was hardcoded and so it was impossible to change it in the nuxt.config.ts of the App.