### PR TITLE
Fix/OIDC i18n

### DIFF
--- a/pages/account/oidc-redirect.client.vue
+++ b/pages/account/oidc-redirect.client.vue
@@ -7,17 +7,15 @@
 definePageMeta({
   layout: false
 })
-// This page is only here to show a blank page with a spinner
-// while the OIDC provider manage the token and redirect to the right page.
+// This page is here to show a blank page with a spinner and redirect
+// to the right page while the OIDC provider manage the token (before this).
 
-// But if the user reach this page without OIDC parameters, then redirect to home page
-const localePath = useLocalePath()
-const router = useRouter()
-onMounted(() => {
-  const urlQuery = window.location.search
-  if (!urlQuery.includes('code=') || !urlQuery.includes('state=')) {
-    router.push(localePath({ path: '/' }))
-  }
+onMounted(async () => {
+  // Get the target page from the querystring
+  const target = new URLSearchParams(window.location.search).get('target')
+  const decodedTarget = target ? decodeURIComponent(target) : '/'
+  // Redirect to the target page
+  await navigateTo(decodedTarget, { replace: true })
 })
 </script>
 <style lang="scss">

--- a/services/AuthService.ts
+++ b/services/AuthService.ts
@@ -40,8 +40,8 @@ export abstract class AuthService extends BaseServiceLocalized {
   private storage: any = null
 
   abstract getConfig(): any
-  abstract loginRedirect(url?: string): Promise<any>
-  abstract logoutRedirect(url?: string): Promise<any>
+  abstract loginRedirect(path?: string): Promise<any>
+  abstract logoutRedirect(path?: string): Promise<any>
   // Add those to the fetcher
   abstract erpInterceptorOnRequest(ctx: oFetchRequestCtx): Promise<void>
   abstract erpInterceptorOnResponseError(ctx: oFetchResponseErrorCtx): Promise<void>
@@ -78,7 +78,7 @@ export abstract class AuthService extends BaseServiceLocalized {
       const profile = await this.ofetch(this.urlEndpointUser)
       if (profile) {
         // Avoid to set the user if it's the same, else it will trigger "watch" everywhere in the app.
-        // This is needed because the OIDC service calls this method even on automatic session refresh.
+        // This is needed because, for example, the OIDC service calls this method even on automatic session refresh.
         const currentUser = this.getUser()
         const newUser = new User(profile)
         if (!isEqual(currentUser.value, newUser)) {
@@ -101,7 +101,7 @@ export abstract class AuthService extends BaseServiceLocalized {
   async setUser(data: AuthUserCredential | User | null): Promise<User | null> {
     const store = this.store()
     if (data) {
-      const user: User | null = data ? new User(data) : null
+      const user: User | null = data instanceof User ? data : data ? new User(data) : null
       store.setUser(user)
       this.setSession(user !== null)
       if (user !== null) {

--- a/services/auth/AuthOIDCService.ts
+++ b/services/auth/AuthOIDCService.ts
@@ -161,7 +161,7 @@ export class AuthOIDCService extends AuthService {
   }
 
   async userUnloaded() {
-    console.log('User unloaded')
+    // Automatically called by the OIDC provider when we log the user out (signoutRedirect)
     try {
       await this.ofetch(this.urlEndpointAuth + '/signout', { method: 'POST' })
     } catch (e) {


### PR DESCRIPTION
Made the oidc i18n compliant. 
Moved the redirection avec OIDC into the oidc-redirect page.
Made clear that methods login and logout want a path as a parameter and not a url.
Cleaned both methods.
Cleaned the userUnloaded.